### PR TITLE
input: passthrough virtio-input device

### DIFF
--- a/drivers/virtio/virtio_input.c
+++ b/drivers/virtio/virtio_input.c
@@ -3,6 +3,7 @@
 #include <linux/virtio.h>
 #include <linux/virtio_config.h>
 #include <linux/input.h>
+#include <linux/input/mt.h>
 
 #include <uapi/linux/virtio_ids.h>
 #include <uapi/linux/virtio_input.h>
@@ -164,6 +165,12 @@ static void virtinput_cfg_abs(struct virtio_input *vi, int abs)
 	virtio_cread(vi->vdev, struct virtio_input_config, u.abs.flat, &fl);
 	input_set_abs_params(vi->idev, abs, mi, ma, fu, fl);
 	input_abs_set_res(vi->idev, abs, re);
+	if (abs == ABS_MT_TRACKING_ID)
+		input_mt_init_slots(vi->idev,
+				    ma, /* input max finger */
+				    INPUT_MT_DIRECT
+					| INPUT_MT_DROP_UNUSED
+					| INPUT_MT_TRACK);
 }
 
 static int virtinput_init_vqs(struct virtio_input *vi)


### PR DESCRIPTION
The virtio-input device event should be passthrough
and send to uplayer directly, since the events get
from host, and already handled in host input driver.

Tracked-On: OAM-90659
Signed-off-by: Yang, Dong <dong.yang@intel.com>